### PR TITLE
ci: add GitHub Actions workflow for linting and type checks

### DIFF
--- a/.github/matchers/svelte-check.json
+++ b/.github/matchers/svelte-check.json
@@ -1,0 +1,18 @@
+{
+	"problemMatcher": [
+		{
+			"owner": "svelte-check",
+			"severity": "error",
+			"pattern": [
+				{
+					"regexp": "^(.+):(\\d+):(\\d+) - (error|warning) (.+)$",
+					"file": 1,
+					"line": 2,
+					"column": 3,
+					"severity": 4,
+					"message": 5
+				}
+			]
+		}
+	]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches: ['*']
+  pull_request:
+    branches: ['*']
+
+jobs:
+  lint-and-check:
+    name: Lint & Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run linters with annotations
+        uses: wearerequired/lint-action@v2
+        with:
+          prettier: true
+          prettier_dir: '.'
+
+      - name: Register svelte-check problem matcher
+        run: echo "::add-matcher::${{ github.workspace }}/.github/matchers/svelte-check.json"
+
+      - name: Run Svelte check
+        run: pnpm check
+
+      - name: Remove svelte-check problem matcher
+        if: always()
+        run: echo "::remove-matcher owner=svelte-check"


### PR DESCRIPTION
Add a CI workflow that runs on push and pull_request to perform linting
and static type checks in a Node 20 + pnpm environment. The workflow:
- checks out the repository and sets up Node.js (v20) and pnpm (v10.16.1)
- caches the pnpm store to speed subsequent runs
- installs dependencies with pnpm --frozen-lockfile
- runs Prettier via wearerequired/lint-action for annotated lint results
- registers a custom problem matcher, runs svelte-check, and removes the
  matcher afterwards

Include a problem matcher file for svelte-check that maps svelte-check
output to GitHub Actions annotations, enabling inline error/warning
reporting in pull requests and the Actions UI.